### PR TITLE
🐛 Parse admonitions within lists

### DIFF
--- a/src/parser.spec.ts
+++ b/src/parser.spec.ts
@@ -24,6 +24,25 @@ describe('parser', () => {
 `);
   });
 
+  test('should render a callout within a list', () => {
+    md.use(plugin());
+    expect(md.render(`- A list\n\n    :::note\n    Info\n    ABC\n    :::\n`)).toMatchInlineSnapshot(`
+"<ul>
+<li><p>A list</p>
+
+    <div class=\\"admonition admonition-note\\">
+      <div class=\\"admonition-heading\\">
+        <h5><div class=\\"admonition-icon\\">ℹ️</div> note</h5>
+      </div>
+      <div class=\\"admonition-content\\">
+    <p>Info</p>
+<p>ABC</p>
+</div></div></li>
+</ul>
+"
+`);
+  });
+
   test('should ignore content after callout', () => {
     md.use(plugin());
     expect(

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -11,7 +11,7 @@ export const parser: Remarkable.BlockParsingRule = (
   endLine,
   silent
 ) => {
-  let pos = state.bMarks[startLine] + state.blkIndent;
+  let pos = state.bMarks[startLine] + state.tShift[startLine];
   const max = state.eMarks[startLine];
 
   // Not enough chars or ending line with `:::`.


### PR DESCRIPTION
Fixes: #26

This fix allows the parser to start at the actual indent of the code to be parsed (`state.tShift[startLine]`) instead of the (minimum) indent required for the line by the parent (`state.blkIndent`).